### PR TITLE
Upgrade dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 52f6643704d171e075e3b7c71bfa533c3dc6603e6f62ffbcf819cb92ac3d6865
-updated: 2018-04-16T19:37:30.727704556+01:00
+hash: e107abc943f09fcc67a2db274cb6c947eb89f5eef0199f987fed037c9fc2d7cf
+updated: 2018-05-18T09:05:17.085537+01:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -14,7 +14,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: 59a00e612400e688c7553db01b9b394368660a34
+  version: 1b6b58d3e8111b08c134cd5be190efc2022b07c8
   subpackages:
   - aws
   - aws/awserr
@@ -32,6 +32,8 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkio
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/query
@@ -52,15 +54,17 @@ imports:
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
 - name: github.com/blang/semver
-  version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
+  version: c5e971dbed7850a93c23aa6ff69db5771d8e23b3
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
+- name: github.com/fatih/color
+  version: 2d684516a8861da43017284349b7e303e809ac21
 - name: github.com/go-ini/ini
-  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
+  version: bda519ae5f4cbc60d391ff8610711627a08b86ae
 - name: github.com/golang/protobuf
-  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
+  version: 668a607657a5d387d6333648a2d9c749761fdc69
   subpackages:
   - proto
   - ptypes
@@ -72,21 +76,23 @@ imports:
 - name: github.com/hashicorp/go-cleanhttp
   version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
 - name: github.com/hashicorp/go-getter
-  version: 994f50a6f071b07cfbea9eca9618c9674091ca51
+  version: 3f60ec5cfbb2a39731571b9ddae54b303bb0a969
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-hclog
-  version: ca137eb4b4389c9bc6f1a6d887f056bf16c00510
+  version: 69ff559dc25f3b435631604f573a5fa1efdb6433
 - name: github.com/hashicorp/go-multierror
   version: b7773ae218740a7be65057fc60b366a49b538a44
 - name: github.com/hashicorp/go-plugin
-  version: e2fbc6864d18d3c37b6cde4297ec9fca266d28f1
+  version: e8d22c780116115ae5624720c9af0c97afe4f551
+- name: github.com/hashicorp/go-safetemp
+  version: b1a1dbde6fdc11e3ae79efd9039009e22d4ae240
 - name: github.com/hashicorp/go-uuid
-  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
+  version: 27454136f0364f2d44b1276c552d69105cf8c498
 - name: github.com/hashicorp/go-version
-  version: 4fe82ae3040f80a03d04d2cccb5606a626b8e1ee
+  version: 23480c0665776210b5fbbac6eaaee40e3e6a96b7
 - name: github.com/hashicorp/hcl
-  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
+  version: ef8a98b0bbce4a65b5aa4c368430a80ddc533168
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -97,7 +103,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: 44bad6dbf5490f5da17ec991e664df3d017b706f
+  version: 9db880accff19d9bd953958df738ef0c02b4a311
   subpackages:
   - gohcl
   - hcl
@@ -144,13 +150,15 @@ imports:
   - tfdiags
   - version
 - name: github.com/hashicorp/yamux
-  version: 683f49123a33db61abfb241b7ac5e4af4dc54d55
+  version: 2658be15c5f05e76244154714161f17e3e77de2e
 - name: github.com/jmespath/go-jmespath
-  version: dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
+- name: github.com/mattn/go-colorable
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
   version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/mitchellh/cli
-  version: 33edc47170b5df54d2588696d590c5e20ee583fe
+  version: c48282d14eba4b0817ddef3f832ff8d13851aefd
 - name: github.com/mitchellh/copystructure
   version: d23ffcb85de31694d6ccaa23ccb4a03e55c1303f
 - name: github.com/mitchellh/go-homedir
@@ -162,13 +170,15 @@ imports:
 - name: github.com/mitchellh/hashstructure
   version: 2bca23e0e452137f789efbc8610126fd8b94f73b
 - name: github.com/mitchellh/mapstructure
-  version: 06020f85339e21b2478f756a78e295255ffa4d6a
+  version: bb74f1db0675b241733089d5a1faa5dd8b0ef57b
 - name: github.com/mitchellh/reflectwalk
   version: 63d60e9d0dbc60cf9164e6510889b0db6683d98c
+- name: github.com/oklog/run
+  version: 6934b124db28979da51d3470dadfa34d73d72652
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/posener/complete
-  version: 6bee943216c8cea4cc983c8596346d8945279a1f
+  version: e037c22b2fcfa85e74495388f03892ed194bba76
   subpackages:
   - cmd
   - cmd/install
@@ -178,7 +188,7 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
-  version: 778f2e774c725116edbc3d039dc0dfc1cc62aae8
+  version: 0dad3b6953e73d351ec8ebfd8a8c6b088d320381
 - name: github.com/ulikunitz/xz
   version: 0c6b41e72360850ca4f98dc341fd999726ea007f
   subpackages:
@@ -186,7 +196,7 @@ imports:
   - internal/xlog
   - lzma
 - name: github.com/zclconf/go-cty
-  version: 48ce95f3a00f37ac934ff90a62e377146f9428e1
+  version: d006e4534bc4fbc512383aa98d04d641ea951ba5
   subpackages:
   - cty
   - cty/convert
@@ -196,7 +206,7 @@ imports:
   - cty/json
   - cty/set
 - name: golang.org/x/crypto
-  version: 95a4943f35d008beabde8c11e5075a1b714e6419
+  version: 1a580b3eff7814fc9b40602fd35256c63b50f491
   subpackages:
   - bcrypt
   - blowfish
@@ -209,43 +219,45 @@ imports:
   - openpgp/s2k
   - ssh/terminal
 - name: golang.org/x/net
-  version: d866cfc389cec985d6fda2859936a575a55a3ab6
+  version: 2491c5de3490fced2f6cff376127c667efeed857
   subpackages:
   - context
   - html
   - html/atom
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
   - internal/timeseries
-  - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 83801418e1b59fb1880e363299581ee543af32ca
+  version: 7c87d13f8e835d2fb3a70a2912c811ed0c1d241b
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
+  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: a8101f21cf983e773d0c1133ebc5424792003214
+  version: 7bb2a897381c9c5ab2aeb8614f758d7766af68ff
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 7aea499f9110a479b3777df064372f44188146aa
+  version: 3b7feb1847c899055b799fc77693e376cd4ea0d9
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
+  - channelz
   - codes
   - connectivity
   - credentials
   - encoding
+  - encoding/proto
   - grpclb/grpc_lb_v1/messages
   - grpclog
   - health
@@ -263,10 +275,10 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 187b9e39f103773cf0416d2bbf8122b5d966c592b7b5a0650ec867b7e89f2110
-updated: 2018-01-18T09:36:07.208683Z
+hash: 52f6643704d171e075e3b7c71bfa533c3dc6603e6f62ffbcf819cb92ac3d6865
+updated: 2018-04-16T19:37:30.727704556+01:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -41,6 +41,10 @@ imports:
   - private/protocol/xml/xmlutil
   - service/s3
   - service/sts
+- name: github.com/beamly/go-gocd
+  version: 22c4d041ca9ce74960c6a10e8ab63bf7d05e87a3
+  subpackages:
+  - gocd
 - name: github.com/bgentry/go-netrc
   version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
   subpackages:
@@ -53,10 +57,6 @@ imports:
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
-- name: github.com/beamly/go-gocd
-  version: 9ff9f02728c9ec4c22fbe94d1edc81de50547c13
-  subpackages:
-  - gocd
 - name: github.com/go-ini/ini
   version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
 - name: github.com/golang/protobuf
@@ -114,7 +114,7 @@ imports:
 - name: github.com/hashicorp/logutils
   version: 0dc08b1671f34c4250ce212759ebd880f743d883
 - name: github.com/hashicorp/terraform
-  version: a6008b8a48a749c7c167453b9cf55ffd572b9a5d
+  version: 41e50bd32a8825a84535e353c3674af8ce799161
   subpackages:
   - config
   - config/configschema
@@ -130,6 +130,7 @@ imports:
   - helper/schema
   - helper/structure
   - helper/validation
+  - httpclient
   - moduledeps
   - plugin
   - plugin/discovery
@@ -172,14 +173,12 @@ imports:
   - cmd
   - cmd/install
   - match
-- name: github.com/satori/go.uuid
-  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
 - name: github.com/sergi/go-diff
   version: 1744e2970ca51c86172c8190fadad617561ed6e7
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: 778f2e774c725116edbc3d039dc0dfc1cc62aae8
 - name: github.com/ulikunitz/xz
   version: 0c6b41e72360850ca4f98dc341fd999726ea007f
   subpackages:
@@ -271,6 +270,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,7 @@ import:
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/sergi/go-diff
+  version: ^1.0.0
   subpackages:
   - diffmatchpatch
 testImport:

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
   subpackages:
   - gocd
 - package: github.com/hashicorp/terraform
-  version: ^0.11.2
+  version: ^0.11.7
   subpackages:
   - helper/hashcode
   - helper/schema


### PR DESCRIPTION
Updated dependencies to bring new versions of go-gocd in in prep for config repo resource and upgrade to latest library dependencies.