### PR TITLE
Housekeeping modifications

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![GoDoc](https://godoc.org/github.com/beamly/terraform-provider-gocd/gocd?status.svg)](https://godoc.org/github.com/beamly/terraform-provider-gocd/gocd)
 [![Build Status](https://travis-ci.org/beamly/terraform-provider-gocd.svg?branch=master)](https://travis-ci.org/beamly/terraform-provider-gocd)
 [![codecov](https://codecov.io/gh/beamly/terraform-provider-gocd/branch/master/graph/badge.svg)](https://codecov.io/gh/beamly/terraform-provider-gocd)
-[![Go Report Card](https://goreportcard.com/badge/github.com/beamly/terraform-provider-gocd)](https://goreportcard.com/report/github.com/beamly/terraform-provider-gocd)
+[![codebeat badge](https://codebeat.co/badges/8d206e97-e94e-4957-b5da-8060454ba6dc)](https://codebeat.co/projects/github-com-beamly-terraform-provider-gocd-master)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbeamly%2Fterraform-provider-gocd.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbeamly%2Fterraform-provider-gocd?ref=badge_shield)
+[![Go Report Card](https://goreportcard.com/badge/github.com/beamly/terraform-provider-gocd)](https://goreportcard.com/report/github.com/beamly/terraform-provider-gocd)
 
 Terraform provider for GoCD Server
 

--- a/scripts/go-test.sh
+++ b/scripts/go-test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash -e
 
-set -x
-
 ROOT_DIR=$(pwd)/
 COVERAGE_PATH=${ROOT_DIR}/coverage.txt
 


### PR DESCRIPTION
Making house keeping changes to documentation and debug output

## Description
Making 3 changes which wouldn't all need their own PR:
 - Added a PR template to prompt developers when creating a PR
 - Fixed an incorrect reference to the old `drewsonne` organisation for the codebeat badge
 - Disabled the debug flag in the test wrapper

## Motivation and Context
 - To encourage testing and as a pre-empt to change control, we should have the PR templates
 - All references to the `drewsonne` repo should no longer exist
 - No need for the debug flag if there's no debug doing done as it generates excess output making the logs more difficult to read.

## How has this been tested?
 - This is the same template used on other `beamly`/`zeebox` repositories
 - The badge is displayed in the README.md on the `feature/pr-templates` branch.
 - Tested by running locally, and the script was run as a check on this PR.