### PR TITLE
Add test cases to expand json diff usage

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,8 @@
-#TEST?=$$(go list ./... |grep -v 'vendor')
 TEST?=github.com/beamly/terraform-provider-gocd/gocd/
 GOFMT_FILES?=$$(glide novendor)
 SHELL:=/bin/bash
 
-# For local testing, run `docker-compose up -d`
+# For local testing, run `make testacc`
 SERVER ?=http://127.0.0.1:8153/go/
 TESTARGS ?= -race -coverprofile=profile.out -covermode=atomic
 


### PR DESCRIPTION
Added test cases to make sure error branches are test in the JSON diff suppress function

## Description
Test cases were added to ensure panic, equal, unequal, and one empty value were handled in the expected manner

## Motivation and Context
Branches, especially errors should be tested, and this increases the test coverage to improve that.

## How Has This Been Tested?
They are test cases, their job is to test. The tests pass.
