### PR TITLE
Updated go dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e107abc943f09fcc67a2db274cb6c947eb89f5eef0199f987fed037c9fc2d7cf
-updated: 2018-06-11T11:02:46.770942+01:00
+hash: 86911cf3cb8634a923b686003356702edd089b57a3fe4fd6db5b6630604c739b
+updated: 2018-06-11T11:14:28.438992+01:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -153,7 +153,7 @@ imports:
   - tfdiags
   - version
 - name: github.com/hashicorp/yamux
-  version: a031bd43a737efe86eddece0022fff5ea0bc6abe
+  version: 3520598351bb3500a49ae9563f5539666ae0a27c
 - name: github.com/jmespath/go-jmespath
   version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/mattn/go-colorable

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e107abc943f09fcc67a2db274cb6c947eb89f5eef0199f987fed037c9fc2d7cf
-updated: 2018-05-18T09:05:17.085537+01:00
+updated: 2018-06-11T11:02:46.770942+01:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -14,7 +14,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: 1b6b58d3e8111b08c134cd5be190efc2022b07c8
+  version: 188b472c942900b21391cd177852a41c74694d88
   subpackages:
   - aws
   - aws/awserr
@@ -26,6 +26,7 @@ imports:
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
   - aws/credentials/stscreds
+  - aws/csm
   - aws/defaults
   - aws/ec2metadata
   - aws/endpoints
@@ -36,6 +37,8 @@ imports:
   - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
+  - private/protocol/eventstream
+  - private/protocol/eventstream/eventstreamapi
   - private/protocol/query
   - private/protocol/query/queryutil
   - private/protocol/rest
@@ -62,9 +65,9 @@ imports:
 - name: github.com/fatih/color
   version: 2d684516a8861da43017284349b7e303e809ac21
 - name: github.com/go-ini/ini
-  version: bda519ae5f4cbc60d391ff8610711627a08b86ae
+  version: 06f5f3d67269ccec1fe5fe4134ba6e982984f7f5
 - name: github.com/golang/protobuf
-  version: 668a607657a5d387d6333648a2d9c749761fdc69
+  version: 05f48f4eaf0e05663b562bab533cdd472238ce29
   subpackages:
   - proto
   - ptypes
@@ -103,7 +106,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: 9db880accff19d9bd953958df738ef0c02b4a311
+  version: 36446359d27574bf110611001414da561731b62d
   subpackages:
   - gohcl
   - hcl
@@ -150,7 +153,7 @@ imports:
   - tfdiags
   - version
 - name: github.com/hashicorp/yamux
-  version: 2658be15c5f05e76244154714161f17e3e77de2e
+  version: a031bd43a737efe86eddece0022fff5ea0bc6abe
 - name: github.com/jmespath/go-jmespath
   version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/mattn/go-colorable
@@ -162,7 +165,7 @@ imports:
 - name: github.com/mitchellh/copystructure
   version: d23ffcb85de31694d6ccaa23ccb4a03e55c1303f
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 3864e76763d94a6df2f9960b16a20a33da9f9a66
 - name: github.com/mitchellh/go-testing-interface
   version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/mitchellh/go-wordwrap
@@ -188,7 +191,7 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
-  version: 0dad3b6953e73d351ec8ebfd8a8c6b088d320381
+  version: ea8897e79973357ba785ac2533559a6297e83c44
 - name: github.com/ulikunitz/xz
   version: 0c6b41e72360850ca4f98dc341fd999726ea007f
   subpackages:
@@ -196,7 +199,7 @@ imports:
   - internal/xlog
   - lzma
 - name: github.com/zclconf/go-cty
-  version: d006e4534bc4fbc512383aa98d04d641ea951ba5
+  version: ba988ce11d9994867838957d4c40bb1ad78b433d
   subpackages:
   - cty
   - cty/convert
@@ -206,7 +209,7 @@ imports:
   - cty/json
   - cty/set
 - name: golang.org/x/crypto
-  version: 1a580b3eff7814fc9b40602fd35256c63b50f491
+  version: 8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9
   subpackages:
   - bcrypt
   - blowfish
@@ -219,7 +222,7 @@ imports:
   - openpgp/s2k
   - ssh/terminal
 - name: golang.org/x/net
-  version: 2491c5de3490fced2f6cff376127c667efeed857
+  version: 1e491301e022f8f977054da4c2d852decd59571f
   subpackages:
   - context
   - html
@@ -231,7 +234,7 @@ imports:
   - internal/timeseries
   - trace
 - name: golang.org/x/sys
-  version: 7c87d13f8e835d2fb3a70a2912c811ed0c1d241b
+  version: bff228c7b664c5fce602223a05fb708fd8654986
   subpackages:
   - unix
   - windows
@@ -243,11 +246,11 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: 7bb2a897381c9c5ab2aeb8614f758d7766af68ff
+  version: 32ee49c4dd805befd833990acba36cb75042378c
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 3b7feb1847c899055b799fc77693e376cd4ea0d9
+  version: 39a411827d3b79d942aaeafab095ecf8204f1b0c
   subpackages:
   - balancer
   - balancer/base
@@ -258,11 +261,11 @@ imports:
   - credentials
   - encoding
   - encoding/proto
-  - grpclb/grpc_lb_v1/messages
   - grpclog
   - health
   - health/grpc_health_v1
   - internal
+  - internal/grpcrand
   - keepalive
   - metadata
   - naming
@@ -282,6 +285,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ owners:
   email: drew.sonne@gmail.com
 import:
 - package: github.com/beamly/go-gocd
-  version: ^0.6.14
+  version: ^0.6.16
   subpackages:
   - gocd
 - package: github.com/hashicorp/terraform


### PR DESCRIPTION
Updated glide dependencies to the latest version

## Description
Ran `glide update` to ensure the latest versions of the dependencies are defined in the lock file.

## Related Issue
Outdated dependencies are breaking the build in  #57 .

## Motivation and Context
When travis tries to perform a build, an error is being thrown:

```[ERROR]	Failed to set version on github.com/hashicorp/yamux to 2658be15c5f05e76244154714161f17e3e77de2e: Unable to update checked out version: exit status 128
```

## How Has This Been Tested?
Travis build for this commit has completed successfully.
https://travis-ci.org/beamly/terraform-provider-gocd/builds/390704524?utm_source=github_status&utm_medium=notification