### PR TITLE
Fixes segfault when attempting to check if a non-existant stage exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Get project and install dependencies using glide:
 
     $ go get github.com/beamly/terraform-provider-gocd
     $ cd $GOPATH/src/github.com/beamly/terraform-provider-gocd/
+    $ make before_install
 
 Then you can run tests as follows:
 

--- a/gocd/resource_pipeline_stage.go
+++ b/gocd/resource_pipeline_stage.go
@@ -146,12 +146,12 @@ func resourcePipelineStageExists(d *schema.ResourceData, meta interface{}) (bool
 	client.Lock()
 	defer client.Unlock()
 
-	if stage, err := retrieveStage(pType, name, pipeline, client); err == nil {
+	if stage, err := retrieveStage(pType, name, pipeline, client); (err == nil) && (stage != nil) {
 		d.SetId(fmt.Sprintf("%s/%s/%s", pType, pipeline, stage.Name))
-		return stage != nil, nil
-	} else {
-		return false, err
+		return true, nil
 	}
+
+	return false, err
 }
 
 func resourcePipelineStageCreate(d *schema.ResourceData, meta interface{}) (err error) {


### PR DESCRIPTION
## Description
There is a bug in `resourcePipelineStageExists` which causes a nil stage variable to be dereferenced when the specified stage does not exist.  

## Motivation and Context

Example segfault:
```
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: panic: runtime error: invalid memory address or nil pointer dereference
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb0ca35]
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: goroutine 369 [running]:
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: github.com/drewsonne/terraform-provider-gocd/gocd.resourcePipelineStageExists(0xc42018a460, 0xd8f5e0, 0xc420067520, 0xc42018a400, 0x0, 0x0)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /Users/drews/go/src/github.com/drewsonne/terraform-provider-gocd/gocd/resource_pipeline_stage.go:150 +0x295
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc420078a80, 0xc42054c320, 0xd8f5e0, 0xc420067520, 0xc420066cd8, 0x1000f01204a1401, 0x80000000000)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /Users/drews/go/src/github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:332 +0x36f
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc420078bd0, 0xc42054c2d0, 0xc42054c320, 0x7fe083f3f6c8, 0x0, 0x1000)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /Users/drews/go/src/github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:308 +0x9a
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Refresh(0xc42031b9e0, 0xc4204c3330, 0xc4204c3400, 0x0, 0x0)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /Users/drews/go/src/github.com/drewsonne/terraform-provider-gocd/vendor/github.com/hashicorp/terraform/plugin/resource_provider.go:549 +0x4e
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: reflect.Value.call(0xc4203462a0, 0xc4203aa528, 0x13, 0xde848d, 0x4, 0xc420502f20, 0x3, 0x3, 0x0, 0x0, ...)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /usr/local/opt/go/libexec/src/reflect/value.go:434 +0x905
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: reflect.Value.Call(0xc4203462a0, 0xc4203aa528, 0x13, 0xc42058a720, 0x3, 0x3, 0x0, 0x0, 0xd428e0)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /usr/local/opt/go/libexec/src/reflect/value.go:302 +0xa4
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: net/rpc.(*service).call(0xc420416780, 0xc42006e2d0, 0xc420015760, 0xc4202f0a00, 0xc420488100, 0xc59660, 0xc4204c3330, 0x16, 0xc596a0, 0xc4204c3400, ...)
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /usr/local/opt/go/libexec/src/net/rpc/server.go:381 +0x142
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19: created by net/rpc.(*Server).ServeCodec
    2018-06-12T14:32:04.520Z [DEBUG] plugin.terraform-provider-gocd_v0.1.19:        /usr/local/opt/go/libexec/src/net/rpc/server.go:475 +0x36b
```

## How Has This Been Tested?

`terraform plan` against infrastructure and state that previously caused the above error now successfully produces a plan.
