### PR TITLE
Allow SSL certificate validation to be skipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
 #    - go: tip
   fast_finish: true
 
+env:
+  matrix:
+    - GOCD_URL=http://127.0.0.1:8153/go/
+    - GOCD_URL=https://127.0.0.1:8154/go/ GOCD_SKIP_SSL_CHECK=1
+
 
 cache:
   pip: true

--- a/gocd/provider.go
+++ b/gocd/provider.go
@@ -1,6 +1,7 @@
 package gocd
 
 import (
+	"crypto/tls"
 	"fmt"
 	"github.com/beamly/go-gocd/gocd"
 	"github.com/hashicorp/terraform/helper/logging"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -115,8 +117,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SkipSslCheck: nossl,
 	}
 
-	hClient := &http.Client{
-		Transport: http.DefaultTransport,
+	hClient := &http.Client{}
+
+	if strings.HasPrefix(cfg.Server, "https") {
+		hClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.SkipSslCheck},
+		}
+	} else {
+		hClient.Transport = http.DefaultTransport
 	}
 
 	// Add API logging

--- a/gocd/provider.go
+++ b/gocd/provider.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"log"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -89,18 +90,21 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			url = os.Getenv("GOCD_URL")
 		}
 	}
+	log.Printf("[DEBUG] Using GoCD config 'baseurl': %s", url)
 
 	if rU, ok = d.GetOk("username"); ok {
 		if u, ok = rU.(string); !ok || u == "" {
 			u = os.Getenv("GOCD_USERNAME")
 		}
 	}
+	log.Printf("[DEBUG] Using GoCD config 'username': %s", u)
 
 	if rP, ok = d.GetOk("password"); ok {
 		if p, ok = rP.(string); !ok || p == "" {
 			p = os.Getenv("GOCD_PASSWORD")
 		}
 	}
+	log.Printf("[DEBUG] Using GoCD config 'password': %s", rP)
 
 	if rB, ok = d.GetOk("skip_ssl_check"); ok {
 		if b, ok = rB.(bool); !ok {
@@ -109,6 +113,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			nossl = b
 		}
 	}
+	log.Printf("[DEBUG] Using GoCD config 'skip_ssl_check': %t", url)
 
 	cfg = &gocd.Configuration{
 		Server:       url,
@@ -120,6 +125,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	hClient := &http.Client{}
 
 	if strings.HasPrefix(cfg.Server, "https") {
+		log.Printf("[DEBUG] GoCD is using https.")
 		hClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.SkipSslCheck},
 		}

--- a/gocd/provider_test.go
+++ b/gocd/provider_test.go
@@ -52,10 +52,6 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("GOCD_URL must be set for acceptance tests.")
 	}
 
-	if s := os.Getenv("GOCD_SKIP_SSL_CHECK"); s == "" {
-		t.Fatal("GOCD_SKIP_SSL_CHECK must be set for acceptance tests.")
-	}
-
 	err := testGocdProvider.Configure(terraform.NewResourceConfig(nil))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description
The `skip_ssl_check` parameter is currently ignored as it is only used by the gocd library when the HTTP client is used.

## Motivation and Context
Without this fix we are unable to use this provider with a gocd server that has a self-signed cert or a cert with a mismatched name.

## How Has This Been Tested?
Run locally against a gocd server which exhibited following SSL error:
```x509: certificate is valid for *.domain.com, domain.com, not host.subdomain.domain.com```
