### PR TITLE
Test on golang 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - 1.9.x
+  - 1.10.x
 #  - release
 #  - tip
 


### PR DESCRIPTION
Upgrade travis tests to run on golang 1.1.0

## Description
Added a stage for travis to build the provider in golang 1.1.0