### PR TITLE
Check for 404 error when checking for existence of a pipeline or pipeline template

### DIFF
--- a/gocd/resource_pipeline.go
+++ b/gocd/resource_pipeline.go
@@ -3,6 +3,7 @@ package gocd
 import (
 	"context"
 	"github.com/beamly/go-gocd/gocd"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -291,7 +292,11 @@ func resourcePipelineExists(d *schema.ResourceData, meta interface{}) (bool, err
 	client.Lock()
 	defer client.Unlock()
 	if p, _, err := client.PipelineConfigs.Get(context.Background(), name); err != nil {
-		return false, err
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return false, nil
+		} else {
+			return false, err
+		}
 	} else {
 		return (p.Name == name), nil
 	}

--- a/gocd/test/resource_pipeline.1.rsc.tf
+++ b/gocd/test/resource_pipeline.1.rsc.tf
@@ -1,9 +1,9 @@
 resource "gocd_pipeline_template" "test-pipeline" {
-  name = "template0-terraform"
+  name = "template1-terraform"
 }
 
 resource "gocd_pipeline" "test-pipeline" {
-  name                    = "pipeline0-terraform"
+  name                    = "pipeline1-terraform"
   group                   = "testing"
   template                = "${gocd_pipeline_template.test-pipeline.name}"
   enable_pipeline_locking = true

--- a/gocd/test/resource_pipeline.2.rsc.tf
+++ b/gocd/test/resource_pipeline.2.rsc.tf
@@ -1,9 +1,9 @@
 resource "gocd_pipeline_template" "test-pipeline" {
-  name = "template0-terraform"
+  name = "template2-terraform"
 }
 
 resource "gocd_pipeline" "test-pipeline" {
-  name     = "pipeline0-terraform"
+  name     = "pipeline2-terraform"
   group    = "testing"
   template = "${gocd_pipeline_template.test-pipeline.id}"
 


### PR DESCRIPTION
## Description
Returns false (rather than the error) when a 404 is returned by the API.

## Related Issue
Fixes #64

## Motivation and Context
When state becomes out of sync with what is on GoCD, we are unable to refresh/plan/apply without manually removing the stale entries from the state.

## How Has This Been Tested?
A test has been created that fails when this fix hasn't been applied:
```
    --- FAIL: TestResource/Pipeline (32.58s)
        --- PASS: TestResource/Pipeline/Basic (2.05s)
        --- PASS: TestResource/Pipeline/ImportBasic (13.95s)
            --- PASS: TestResource/Pipeline/ImportBasic/2 (1.65s)
            --- PASS: TestResource/Pipeline/ImportBasic/4 (2.73s)
            --- PASS: TestResource/Pipeline/ImportBasic/5 (9.57s)
        --- PASS: TestResource/Pipeline/FullStack1 (3.58s)
        --- PASS: TestResource/Pipeline/FullStack2 (1.88s)
        --- PASS: TestResource/Pipeline/DisableAutoUpdate (0.03s)
        --- PASS: TestResource/Pipeline/LinkedDependencies (5.13s)
        --- PASS: TestResource/Pipeline/LinkedDependencies#01 (4.68s)
        --- FAIL: TestResource/Pipeline/Missing (1.28s)
            testing.go:527: Step 1 error: Error refreshing: 1 error(s) occurred:
                
                * gocd_pipeline.test-pipeline: 1 error(s) occurred:
                
                * gocd_pipeline.test-pipeline: gocd_pipeline.test-pipeline: Received HTTP Status '404 Not Found': {
                  "message": "Either the resource you requested was not found, or you are not authorized to perform this action."
                }
```
