### PR TITLE
Upgrade to go-gocd 0.7.1 (supports latest Pipeline API)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gocd/gocd-server:v17.10.0
+FROM gocd/gocd-server:v18.7.0
 
 ARG UID
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,12 +25,12 @@ after_success: report_coverage cleanup
 	go get -u github.com/goreleaser/goreleaser
 
 deploy_on_tag:
-	gem install --no-ri --no-rdoc fpm
+	git clean -fd
 	go get
 	goreleaser
 
 deploy_on_develop:
-	gem install --no-ri --no-rdoc fpm
+	git clean -fd
 	go get
 	goreleaser --snapshot
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,18 +22,17 @@ script: testacc
 after_failure: cleanup
 
 after_success: report_coverage cleanup
-	go get -u github.com/goreleaser/goreleaser
 
-deploy_on_tag:
+prepare_goreleaser:
+	go get github.com/goreleaser/goreleaser
 	git clean -fd
 	go get
-	goreleaser
 
-deploy_on_develop:
-	git clean -fd
-	go get
-	goreleaser --snapshot
+deploy_on_tag: prepare_goreleaser
+	goreleaser --debug
 
+deploy_on_develop: prepare_goreleaser
+	goreleaser --debug --rm-dist --snapshot
 
 ## General Targets
 teardown-test-gocd:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-provider-gocd 0.1.22
+# terraform-provider-gocd 0.1.23
 
 [![Join the chat at https://gitter.im/beamly/go-gocd](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/beamly/go-gocd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GoDoc](https://godoc.org/github.com/beamly/terraform-provider-gocd/gocd?status.svg)](https://godoc.org/github.com/beamly/terraform-provider-gocd/gocd)
@@ -36,7 +36,6 @@ __NOTE__: Given the requirements by hashicorp for SLA's to be set for importing 
      - [`gocd_environment_association`](#gocd_environment_association)
 
 ## Data
-
 
  - [`gocd_task_definition`](#gocd_task_definition)
  - [`gocd_job_definition`](#gocd_job_definition)
@@ -180,7 +179,8 @@ resource "gocd_pipeline" "build" {
  - `group` - (Required) The name of the pipeline group to deploy into.
  - `materials` - (Required) The list of materials to be used by pipeline. At least one material must be specified. Each `materials` block supports fields documented below.
  - `label_template` - (Optional)  The label template to customise the pipeline instance label.
- - `enable_pipeline_locking` - (Optional)  Whether pipeline is locked to run single instance or not.
+ - `enable_pipeline_locking` - (Optional, Deprecated)  Whether pipeline is locked to run single instance or not. See notes below.
+ - `lock_behavior` - (Optional) Whether pipeline is locked to run single instance. `none` (never lock), `lockOnFailure` (only lock after a failure) or `unlockWhenFinished` (lock whilst running, then always unlock). See notes below.
  - `template` - (Optional)  The name of the template used by pipeline. A `gocd_pipeline_stage` can not be assigned to a `gocd_pipeline` it `template` is set.
  - `parameters` - (Optional) A [map](https://www.terraform.io/docs/configuration/variables.html#maps) of parameters to be used for substitution in a pipeline or pipeline template.
  - `environment_variables` - (Optional) The list of environment variables that will be passed to all tasks (commands) that are part of this pipeline. Each `environment_variables` block supports fields documented below.
@@ -197,6 +197,13 @@ Type `materials` block supports:
  - `type` (Required) The type of a material. Can be one of git, dependency.
  - `attributes` (Required) A [map](https://www.terraform.io/docs/configuration/variables.html#maps) of attributes for each material type. See the [GoCD API Documentation](https://api.gocd.org/current/#the-pipeline-material-object) for each material type attributes.
 
+##### Locking 
+
+Locking behaviour is now controlled by 2 properties: `lock_behavior` and `enable_pipeline_locking`. A plan may not include both.
+
+The GoCD Pipeline API changed from v17.12.0 to use a 3-state `lock_behaviour` property instead of the old boolean `enable_pipeline_locking`. You may still use `enable_pipeline_locking` in your plan, this will be mapped to `lock_behaviour = 'none' or 'lockOnFailure'` if you use a later version of GoCD.
+
+You may also use `lock_behaviour = 'lockOnFailure' or 'none'` in plans run on older versions of GoCD. These will be mapped back to `enable_pipeline_locking = true or false`. You will however not be able to use `lock_behavior = 'unlockWhenFinished'` on older versions; this value will not be persisted, and you will find replanning will always give you a diff.
 
 #### Attributes Reference
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       AGENT_AUTO_REGISTER_KEY: terraform-testing
   gocd-agent:
-   image: gocd/gocd-agent-ubuntu-16.04:v17.10.0
+   image: gocd/gocd-agent-ubuntu-16.04:v18.7.0
    links:
      - gocd-server:server
    depends_on:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 86911cf3cb8634a923b686003356702edd089b57a3fe4fd6db5b6630604c739b
-updated: 2018-06-11T11:14:28.438992+01:00
+updated: 2018-08-16T21:59:47.937732235+01:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -47,7 +47,7 @@ imports:
   - service/s3
   - service/sts
 - name: github.com/beamly/go-gocd
-  version: 22c4d041ca9ce74960c6a10e8ab63bf7d05e87a3
+  version: 5bad04c88a6bb9a687ddbc65d804c5b8eca7bb55
   subpackages:
   - gocd
 - name: github.com/bgentry/go-netrc
@@ -123,7 +123,7 @@ imports:
 - name: github.com/hashicorp/logutils
   version: 0dc08b1671f34c4250ce212759ebd880f743d883
 - name: github.com/hashicorp/terraform
-  version: 41e50bd32a8825a84535e353c3674af8ce799161
+  version: 6dfc4d748de9cda23835bc5704307ed45e839622
   subpackages:
   - config
   - config/configschema
@@ -191,7 +191,7 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
-  version: ea8897e79973357ba785ac2533559a6297e83c44
+  version: e4b0c6d7829bcf64435536c4a88f4088a3c76203
 - name: github.com/ulikunitz/xz
   version: 0c6b41e72360850ca4f98dc341fd999726ea007f
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ owners:
   email: drew.sonne@gmail.com
 import:
 - package: github.com/beamly/go-gocd
-  version: ^0.6.16
+  version: ^0.7.1
   subpackages:
   - gocd
 - package: github.com/hashicorp/terraform

--- a/gocd/test/resource_pipeline.1.rsc.tf
+++ b/gocd/test/resource_pipeline.1.rsc.tf
@@ -6,7 +6,7 @@ resource "gocd_pipeline" "test-pipeline" {
   name                    = "pipeline1-terraform"
   group                   = "testing"
   template                = "${gocd_pipeline_template.test-pipeline.name}"
-  enable_pipeline_locking = true
+  lock_behavior           = "lockOnFailure"
   label_template          = "build-$${COUNT}"
 
   materials = [


### PR DESCRIPTION
## Description
Upgrade to go-gocd 0.7.1 (supports latest Pipeline API)

Also:
* Add support for lock_behavior, see notes below
* Move tests to GoCD v18.7.0

Locking behaviour is now controlled by 2 properties: `lock_behavior` and `enable_pipeline_locking`. A plan may not include both.

The GoCD Pipeline APi changed from v17.12.0 to use a 3-state `lock_behaviour` property instead of the old boolean `enable_pipeline_locking`. You may still use `enable_pipeline_locking` in your plan, this will be mapped to `lock_behaviour = 'none' or 'lockOnFailure'` if you use a later version of GoCD.

You may also use `lock_behaviour = 'lockOnFailure' or 'none'` in plans run on older versions of GoCD. These will be mapped back to `enable_pipeline_locking = true or false`. You will however not be able to use `lock_behavior = 'unlockWhenFinished'` on older versions; this value will not be persisted, and you will find replanning will always give you a diff.

## Related Issue
Fixes https://github.com/beamly/terraform-provider-gocd/issues/66

## How Has This Been Tested?
See updated tests, plus switch to latest GoCD in Dockerfile & docker-compose. Has been tested against 18.7.0 and 17.10.0 locally. At some point it we should align the versions tested on build with that of beamly/go-gocd


