### PR TITLE
[BREAKING CHANGE] Make the filter a list of strings rather than a block/map - prevents permadiffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ resource "gocd_pipeline" "build" {
       attributes {
         name = "terraform-provider-gocd"
         url = "https://github.com/beamly/terraform-provider-gocd.git"
+        filter = ["file1", "file2"]
       }
     }
   ]
@@ -196,7 +197,7 @@ The `environment_variables` block supports:
 Type `materials` block supports:
 
  - `type` (Required) The type of a material. Can be one of git, dependency.
- - `attributes` (Required) A [map](https://www.terraform.io/docs/configuration/variables.html#maps) of attributes for each material type. See the [GoCD API Documentation](https://api.gocd.org/current/#the-pipeline-material-object) for each material type attributes.
+ - `attributes` (Required) A [map](https://www.terraform.io/docs/configuration/variables.html#maps) of attributes for each material type. See the [GoCD API Documentation](https://api.gocd.org/current/#the-pipeline-material-object) for each material type attributes. Note: any `filter` should be specified as a list of files to ignore (rather than an map containing an `ignore` attribute).
 
 ##### Locking 
 

--- a/gocd/test/resource_pipeline.0.rsc.tf
+++ b/gocd/test/resource_pipeline.0.rsc.tf
@@ -18,12 +18,10 @@ resource "gocd_pipeline" "test-pipeline" {
         branch      = "feature/my-addition"
         destination = "gocd-dir"
 
-        filter {
-          ignore = [
-            "one",
-            "two",
-          ]
-        }
+        filter = [
+          "one",
+          "two",
+        ]
       }
     },
   ]

--- a/gocd/test/resource_pipeline.2.rsc.tf
+++ b/gocd/test/resource_pipeline.2.rsc.tf
@@ -18,12 +18,10 @@ resource "gocd_pipeline" "test-pipeline" {
         destination = "gocd-dir"
 
         //        auto_update = true
-        filter {
-          ignore = [
-            "one",
-            "two",
-          ]
-        }
+        filter = [
+          "one",
+          "two",
+        ]
       }
     },
   ]

--- a/gocd/test/resource_pipeline.4.rsc.tf
+++ b/gocd/test/resource_pipeline.4.rsc.tf
@@ -20,13 +20,11 @@ resource "gocd_pipeline" "test-pipeline" {
         branch = "master"
 
         //        auto_update = true
-        filter {
-          ignore = [
-            "gocd-agents/Dockerfile.base",
-            "Makefile",
-            "gocd-agents/files/base/",
-          ]
-        }
+        filter = [
+          "gocd-agents/Dockerfile.base",
+          "Makefile",
+          "gocd-agents/files/base/",
+        ]
       }
     },
   ]

--- a/gocd/test/resource_pipeline.5.rsc.tf
+++ b/gocd/test/resource_pipeline.5.rsc.tf
@@ -200,13 +200,11 @@ resource "gocd_pipeline" "test-pipeline" {
       attributes {
         url = "git@github.com:company/gocd-ecsagents.git"
 
-        filter = {
-          ignore = [
-            "company-gocd-agents/Dockerfile.base",
-            "Makefile",
-            "company-gocd-agents/files/base/",
-          ]
-        }
+        filter = [
+          "company-gocd-agents/Dockerfile.base",
+          "Makefile",
+          "company-gocd-agents/files/base/",
+        ]
 
         invert_filter = true
         branch        = "master"


### PR DESCRIPTION
## Description
_This is a breaking change (will need a new major release)._ 

Material filters were previously specified as:
```
filter {
   ignore = ["a", "b", "c"]
}
```

When creating tf modules where this block was calculated from a variable, and that variable was an empty list of files, the provider would cause a permanent diff between the plan and the state in gocd. The HCL templating language and the GoCD API did not allow for this to be worked around without a schema change.

Material filters are now specified as:
```
filter = ["a", "b", "c"]
```
