### PR TITLE
Fixes error with managing pipeline environment associations in later versions of GoCD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gocd/gocd-server:v18.12.0
+FROM gocd/gocd-server:v19.5.0
 
 ARG UID
 

--- a/glide.lock
+++ b/glide.lock
@@ -50,7 +50,7 @@ imports:
   - service/s3
   - service/sts
 - name: github.com/beamly/go-gocd
-  version: b9b55147ddfa2dcfcbcbafae2e6b1cb65ff9e8e3
+  version: e2f6fe735ace5a23a3fe4f07adaf8505ec430f73
   subpackages:
   - gocd
 - name: github.com/bgentry/go-netrc

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,11 +2,11 @@ package: github.com/beamly/terraform-provider-gocd
 homepage: https://github.com/beamly/terraform-provider-gocd
 license: LGPL-2.0
 owners:
-- name: Drew J. Sonne
-  email: drew.sonne@gmail.com
+- name: Beamly
+  email: chris@beamly.com
 import:
 - package: github.com/beamly/go-gocd
-  version: ^0.7.5
+  version: ^0.7.6
   subpackages:
   - gocd
 - package: github.com/hashicorp/terraform

--- a/gocd/resource_environment_association.go
+++ b/gocd/resource_environment_association.go
@@ -85,7 +85,8 @@ func resourceEnvironmentAssociationCreate(d *schema.ResourceData, meta interface
 	defer client.Unlock()
 	env, _, err := client.Environments.Patch(context.Background(), environment, &gocd.EnvironmentPatchRequest{
 		Pipelines: &gocd.PatchStringAction{
-			Add: []string{pipeline},
+			Add:    []string{pipeline},
+			Remove: []string{},
 		},
 	})
 	if err != nil {
@@ -126,6 +127,7 @@ func resourceEnvironmentAssociationDelete(d *schema.ResourceData, meta interface
 	client := meta.(*gocd.Client)
 	_, _, err := client.Environments.Patch(context.Background(), environment, &gocd.EnvironmentPatchRequest{
 		Pipelines: &gocd.PatchStringAction{
+			Add:    []string{},
 			Remove: []string{value},
 		},
 	})


### PR DESCRIPTION
Before:

```
    --- FAIL: TestResource/EnvironmentAssociation (1.74s)
        --- FAIL: TestResource/EnvironmentAssociation/Import (0.80s)
            <autogenerated>:1: Step 0 error: Error applying: 1 error(s) occurred:

                * gocd_environment_association.test-environment-association: 1 error(s) occurred:

                * gocd_environment_association.test-environment-association: Received HTTP Status '422 Unprocessable Entity': {
                  "message": "Could not read property 'remove' as a JsonArray containing string in `{\"add\":[\"test-cikhrwatth\"],\"remove\":null}`"
                }
        --- FAIL: TestResource/EnvironmentAssociation/Basic (0.94s)
            <autogenerated>:1: Step 0 error: Error applying: 1 error(s) occurred:

                * gocd_environment_association.test-environment-association: 1 error(s) occurred:

                * gocd_environment_association.test-environment-association: Received HTTP Status '422 Unprocessable Entity': {
                  "message": "Could not read property 'remove' as a JsonArray containing string in `{\"add\":[\"test-pipeline\"],\"remove\":null}`"
                }
```

After:

```
=== RUN   TestResource/Environment
=== RUN   TestResource/Environment/Import
=== RUN   TestResource/Environment/Basic
=== RUN   TestResource/EnvironmentAssociation
=== RUN   TestResource/EnvironmentAssociation/Import
=== RUN   TestResource/EnvironmentAssociation/Basic
```
